### PR TITLE
Improve robustness of `options.type`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const typeMappings = {
 };
 
 function checkType(type) {
-	if (type in typeMappings) {
+	if (Object.hasOwnProperty.call(typeMappings, type)) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function checkType(type) {
 	throw new Error(`Invalid type specified: ${type}`);
 }
 
-const matchType = (type, stat) => type === undefined || stat[typeMappings[type]]();
+const matchType = (type, stat) => stat[typeMappings[type]]();
 
 const toPath = urlOrPath => urlOrPath instanceof URL ? fileURLToPath(urlOrPath) : urlOrPath;
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,11 @@ test('async', async t => {
 		message: 'Invalid type specified: rainbows',
 	});
 
+	await t.throwsAsync(locatePath(['fixture'], {type: 'toString'}), {
+		instanceOf: Error,
+		message: 'Invalid type specified: toString',
+	});
+
 	await t.throwsAsync(locatePath(['fixture'], {type: 1}), {
 		instanceOf: Error,
 		message: 'Invalid type specified: 1',
@@ -54,6 +59,13 @@ test('sync', t => {
 	}, {
 		instanceOf: Error,
 		message: 'Invalid type specified: rainbows',
+	});
+
+	t.throws(() => {
+		locatePathSync(['fixture'], {type: 'toString'});
+	}, {
+		instanceOf: Error,
+		message: 'Invalid type specified: toString',
 	});
 
 	t.throws(() => {


### PR DESCRIPTION
Updated `checkType` to only allow `type` properties on the `typeMappings` object (as opposed to any property down the prototype chain). Removed `type === undefined` check in `matchType` as `options.type` is validated at the top of both sync and async APIs to be `file` or `directory`. I ran `npm test` locally with no issues, but feel free to close if I'm missing something.