### PR TITLE
Don't throw if entry doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,13 @@ export function locatePathSync(
 
 	for (const path_ of paths) {
 		try {
-			const stat = statFunction(path.resolve(cwd, path_), { throwIfNoEntry: false });
+			const stat = statFunction(path.resolve(cwd, path_), {
+				throwIfNoEntry: false
+			});
+
+			if (!stat) {
+				continue;
+			}
 
 			if (matchType(type, stat)) {
 				return path_;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ export function locatePathSync(
 
 	for (const path_ of paths) {
 		try {
-			const stat = statFunction(path.resolve(cwd, path_));
+			const stat = statFunction(path.resolve(cwd, path_), { throwIfNoEntry: false });
 
 			if (matchType(type, stat)) {
 				return path_;

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ export function locatePathSync(
 	for (const path_ of paths) {
 		try {
 			const stat = statFunction(path.resolve(cwd, path_), {
-				throwIfNoEntry: false
+				throwIfNoEntry: false,
 			});
 
 			if (!stat) {


### PR DESCRIPTION
Inspired by [this blog post](https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-2/), I set out to make metro faster.

![image](https://user-images.githubusercontent.com/3917428/217021288-cb7d84e2-d31a-44ec-a525-9bfda33e9c03.png)

Even getting the stack traces from the failures of `fs.statSync` alone is occupying a non-trivial amount of time, but just like in the blog post, we can pass in `throwIfNoEntry: false` to save some CPU time here